### PR TITLE
PLAT-2027 update deprecated error accessor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'rails', '> 3.0.0'
+gem 'rails', '> 6.0.0'
 
 group :development do
   gem 'jeweler', '2.3.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,7 +198,7 @@ DEPENDENCIES
   jeweler (= 2.3.9)
   minitest (~> 5.18)
   mocha (~> 2.0)
-  rails (> 3.0.0)
+  rails (> 6.0.0)
 
 BUNDLED WITH
    2.3.3

--- a/lib/active_model/dynamic_errors.rb
+++ b/lib/active_model/dynamic_errors.rb
@@ -13,8 +13,9 @@ module ActiveModel
     def full_messages
       full_messages = []
 
-      each do |attribute, messages|
-        messages = Array.wrap(messages)
+      each do |error|
+        attribute = error.attribute
+        messages = Array.wrap(error.message)
         next if messages.empty?
 
         if attribute == :base


### PR DESCRIPTION
One of several places we're seeing this deprecation warning. I don't know exactly where/how this gem is used but the fix seems easy enough. [logs](https://app.datadoghq.com/logs?query=env%3Aproduction%20app%3Areverb%20%40%40event_name%3Arails.deprecation_warning%20%22%2Adynamic_errors.rb%2A%22%20&agg_q=&agg_q_source=&cols=%40data.stacktrace_hashcode&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&saved-view-id=912874&sort_m=&sort_t=&stream_sort=time%2Cdesc&top_n=&top_o=&viz=stream&x_missing=&from_ts=1708888442432&to_ts=1708974842432&live=true)